### PR TITLE
Adding postfix's resolv file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,8 @@ RUN 	apt-get update && \
 
 ADD run-postfix.sh /etc/service/app/run
 
+RUN mkdir -p /var/spool/postfix/etc/
+
+ADD resolv.conf  /var/spool/postfix/etc/resolv.conf
+
 ENTRYPOINT ["/sbin/my_init"]

--- a/resolv.conf
+++ b/resolv.conf
@@ -1,0 +1,2 @@
+nameserver 8.8.8.8
+nameserver 8.8.4.4


### PR DESCRIPTION
For some reason postfix is not using the host resolve.conf file and aws name servers will not resolve google's relay address